### PR TITLE
Fix compilation with nim version 0.15.0

### DIFF
--- a/src/nes/mem.nim
+++ b/src/nes/mem.nim
@@ -119,7 +119,7 @@ proc `control=`(n: var Noise, val: uint8) =
 
 proc `period=`(n: var Noise, val: uint8) =
   n.mode = (val and 0x80) == 0x80
-  n.timerPeriod = noiseTable[val and 0x0F]
+  n.timerPeriod = noiseTable[uint64(val and 0x0F)]
 
 proc `length=`(n: var Noise, val: uint8) =
   n.lengthValue = lengthTable[val shr 3]
@@ -128,7 +128,7 @@ proc `length=`(n: var Noise, val: uint8) =
 proc `control=`(d: var DMC, val: uint8) =
   d.irq = val.bit(7)
   d.loop = val.bit(6)
-  d.tickPeriod = dmcTable[val and 0x0F]
+  d.tickPeriod = dmcTable[uint64(val and 0x0F)]
 
 proc restart*(d: var DMC) =
   d.currentAddress = d.sampleAddress

--- a/src/nes/ppu.nim
+++ b/src/nes/ppu.nim
@@ -16,8 +16,8 @@ proc initPalette: array[0x40'u8, Color] =
     0xE4E594, 0xCFEF96, 0xBDF4AB, 0xB3F3CC, 0xB5EBF2, 0xB8B8B8, 0x000000, 0x000000]
 
   for i, x in result.mpairs:
-    x = (r: uint8(cs[i] shr 16), g: uint8(cs[i] shr 8 and 0xFF),
-         b: uint8(cs[i] and 0xFF), a: 255'u8)
+    x = (r: uint8(cs[(int)i] shr 16), g: uint8(cs[(int)i] shr 8 and 0xFF),
+         b: uint8(cs[(int)i] and 0xFF), a: 255'u8)
 
 const palette* = initPalette()
 


### PR DESCRIPTION
Just a small pull request to make nimes compile with the latest version of Nim. Some changes should be made to replace the expr and stmt with the new names (typed and untyped). But that doesn't prohibit compilation it just makes it a bit easier to read.
